### PR TITLE
Adding more cjk punctuations where it should ぺこ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Cache
+__pycache__
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+

--- a/pekofy.py
+++ b/pekofy.py
@@ -11,7 +11,7 @@ def pekofy(input_text):
         return "NO_LETTER"
 
     en_punctuation_list = ['.', '?', '!', '\]', '\n']
-    jp_punctuation_list = ['。', '？', '！', '」', '・']
+    jp_punctuation_list = ['。', '？', '！', '」', '・', '”', '】', '』', '；']
     punctuation_list = en_punctuation_list + jp_punctuation_list
 
     jp_keyword = 'ぺこ'


### PR DESCRIPTION
Since this bot is also being run on [r/VtuberV8](https://www.reddit.com/r/VtuberV8/) (which is a predominantly Chinese speaking subreddit), most of the time "ぺこ" is only being appended at the end of a whole paragraph, and that kind of bugs me when I see it in action. Hopefully this slightly mitigates the issue.

I am a bit uncertain about commas for `，` and `、` though, as sentences in Japanese and Chinese text are normally more dense, adding comma between every sentences would make sense; but that kinda makes it differ from the original version. I left that part out