### PR TITLE
Handle Decimal Number Edge Case

### DIFF
--- a/pekofy.py
+++ b/pekofy.py
@@ -43,6 +43,8 @@ def pekofy(input_text):
     for match in punctuation_pattern.finditer(new_text):
         i = match.start() + offset # match point
         last_word = regex.search(r'[^\W_]', new_text[i::-1]) # find the nearest alphanumeric behind match point
+        if is_decimal_number(new_text, i, last_word.group()):
+            continue
         try:
             j = i - last_word.start() + 1 # index to insert keyword
 
@@ -77,3 +79,13 @@ def pekofy(input_text):
     new_text = profanity.censor(new_text, censor_char='\*', middle_only=True)
     
     return new_text
+
+# Checks if the match is a decimal number
+def is_decimal_number(text, index_with_offset, last_word):
+    index_after = index_with_offset + 1
+    # Guard to check if the previous char is a digit and whether this is the end of a sentence
+    if not last_word.isdigit() or index_after >= len(text):
+        return False
+    if text[index_after].isdigit():
+        return True
+    return False

--- a/pekofy.py
+++ b/pekofy.py
@@ -43,9 +43,9 @@ def pekofy(input_text):
     for match in punctuation_pattern.finditer(new_text):
         i = match.start() + offset # match point
         last_word = regex.search(r'[^\W_]', new_text[i::-1]) # find the nearest alphanumeric behind match point
-        if is_decimal_number(new_text, i, last_word.group()):
-            continue
         try:
+            if is_decimal_number(new_text, i last_word.group()):
+                continue
             j = i - last_word.start() + 1 # index to insert keyword
 
             if is_japanese(last_word.group()):

--- a/pekofy.py
+++ b/pekofy.py
@@ -44,7 +44,7 @@ def pekofy(input_text):
         i = match.start() + offset # match point
         last_word = regex.search(r'[^\W_]', new_text[i::-1]) # find the nearest alphanumeric behind match point
         try:
-            if is_decimal_number(new_text, i last_word.group()):
+            if is_decimal_number(new_text, i, last_word.group()):
                 continue
             j = i - last_word.start() + 1 # index to insert keyword
 


### PR DESCRIPTION
### Description
I noticed on the Hololive subreddit that pekofy-bot has an edge case where if a user pekofys a sentence that contains a decimal number, peko would be added in between the number as it counts as a match. 

### Issue
When a user uses !pekofy on a sentence that contains a decimal number, the sentence is improperly injected with a peko in the decimal number.

Example:
![image](https://user-images.githubusercontent.com/97015436/147917529-b83c82bf-c086-480d-8fb0-ba4edf934c6c.png)

### Potential Solution
Please let me know if the code below is satisfactory, I added a function just to check whether a match is a decimal number since I did not want to mess with the regex already in place. I've also only tested this using english phrases.